### PR TITLE
fix: Correct CI setup and fix analysis errors

### DIFF
--- a/lib/ui/widgets/main_drawer_widget.dart
+++ b/lib/ui/widgets/main_drawer_widget.dart
@@ -10,6 +10,7 @@ import 'package:rag/app/app.router.dart';
 import 'package:rag/ui/widgets/link_tile.dart';
 import 'package:settings/settings.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:stacked_services/stacked_services.dart';
 import 'package:stacked_themes/stacked_themes.dart';
 import 'package:ui/ui.dart';
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -51,9 +51,13 @@ scripts:
 
   ci_integration_test:
     run: |
-      docker run --rm --pull always -p 8000:8000 --name surrealdb surrealdb/surrealdb:latest start memory -A --user root --pass root &
+      export PATH=.:$PATH
+      ./chromedriver --port=4444 &
+      sleep 3
+      sudo docker run --rm --pull always -p 8000:8000 --name surrealdb surrealdb/surrealdb:latest start memory -A --user root --pass root &
       melos exec --concurrency 1 -- flutter drive --driver=test_driver/integration_test.dart --target integration_test/all_tests.dart -d web-server --release --browser-name=chrome
-      docker container stop surrealdb
+      sudo docker container stop surrealdb
+      pkill chromedriver
     description: Run integration tests for all packages in CI environment
     packageFilters:
       dirExists: integration_test

--- a/packages/evaluation/pubspec.yaml
+++ b/packages/evaluation/pubspec.yaml
@@ -15,9 +15,10 @@ dependencies:
   stacked_services: ^1.6.0
 
 dev_dependencies:
+  build_runner: ^2.4.13
   flutter_test:
     sdk: flutter
-  mockito:
+  mockito: ^5.4.1
   stacked_generator: ^2.0.0
   very_good_analysis: ^9.0.0
 

--- a/packages/settings/lib/src/ui/views/settings/settings_view.dart
+++ b/packages/settings/lib/src/ui/views/settings/settings_view.dart
@@ -100,6 +100,7 @@ import 'package:ui/ui.dart';
       name: 'stop',
       validator: SettingsValidators.validateStop,
     ),
+    FormTextField(name: 'ragPipelineLevel'),
   ],
 )
 class SettingsView extends StackedView<SettingsViewModel> with $SettingsView {

--- a/packages/settings/lib/src/ui/views/startup/startup_viewmodel.dart
+++ b/packages/settings/lib/src/ui/views/startup/startup_viewmodel.dart
@@ -14,7 +14,6 @@ class StartupViewModel extends BaseViewModel {
     // This is where you can make decisions on where your app should navigate
     // when you have custom startup logic
     await _navigationService.replaceWithSettingsView(
-      inPackage: true,
       showSystemPromptDialogFunction: showSystemPromptDialog,
       showPromptTemplateDialogFunction: showPromptTemplateDialog,
     );


### PR DESCRIPTION
## Description

This commit fixes the continuous integration (CI) setup and resolves several analysis errors that were preventing the project from being built and tested successfully.

The following changes were made:

- **CI Script:** The `ci_integration_test` script in `melos.yaml` has been updated to:
  - Use `sudo` for Docker commands to resolve permission issues.
  - Prepend the current directory to the `PATH` to ensure the correct `chromedriver` is used.
  - Automatically start and stop `chromedriver` as part of the script.
- **Dependencies:** The `build_runner` and `mockito` dev dependencies were added to the `evaluation` package's `pubspec.yaml` to fix a missing mock file issue.
- **Analysis Errors:**
  - Added a missing import for `stacked_services` in `main_drawer_widget.dart`.
  - Added a missing `FormTextField` definition for `ragPipelineLevel` in `settings_view.dart`.
  - Removed an obsolete `inPackage` parameter from a navigation call in `startup_viewmodel.dart`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
